### PR TITLE
Updated dependency and readme.

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@
 A stylelint config based on [sass-guidelin.es](https://sass-guidelin.es/) and
 [stylelint-config-sass-guidelines](https://github.com/bjankord/stylelint-config-sass-guidelines).
 
+## Requirements
+
+The used version of 'stylelint-config-sass-guidelines' (^5.4.0) requires Node.js 6.x or greater.
+
 ## Installation
 
 ```console
@@ -26,7 +30,6 @@ Set your stylelint config to:
 Simply add a `"rules"` key to your config and add your overrides there.
 
 For example, to change the `indentation` to tabs and turn off the `number-leading-zero` rule:
-
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -5,10 +5,6 @@
 A stylelint config based on [sass-guidelin.es](https://sass-guidelin.es/) and
 [stylelint-config-sass-guidelines](https://github.com/bjankord/stylelint-config-sass-guidelines).
 
-## Requirements
-
-The used version of 'stylelint-config-sass-guidelines' (^5.4.0) requires Node.js 6.x or greater.
-
 ## Installation
 
 ```console

--- a/package.json
+++ b/package.json
@@ -25,12 +25,15 @@
     "index.js"
   ],
   "dependencies": {
-    "stylelint-config-sass-guidelines": "^5.4.0"
+    "stylelint-config-sass-guidelines": "^7.0.0"
   },
   "scripts": {
     "release:major": "npm version major -m \"Released version %s\" && npm publish && git push --follow-tags",
     "release:minor": "npm version minor -m \"Released version %s\" && npm publish && git push --follow-tags",
     "release:patch": "npm version patch -m \"Released version %s\" && npm publish && git push --follow-tags"
+  },
+  "engines": {
+    "node": ">=10"
   },
   "babel": {
     "presets": [

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "index.js"
   ],
   "dependencies": {
-    "stylelint-config-sass-guidelines": "^4.1.0"
+    "stylelint-config-sass-guidelines": "^5.4.0"
   },
   "scripts": {
     "release:major": "npm version major -m \"Released version %s\" && npm publish && git push --follow-tags",


### PR DESCRIPTION
## Problem
When installing and using the package inside a project we have some 'unmet peer dependency' problems and the stylelint doesn't work.
e.g. `Error: Could not find "stylelint-order".`

This stylelint package is based on the `stylelint-config-sass-guidelines` (v.^4.1.0).
The 'unmet peer dependency' problems come from the `stylelint-config-sass-guidelines` package, this got some updates which will also fix the problem (i.e. v.5.0.0)

## Solution
To solve our problem we should update the version of the dependency in our package.json file.
There were multiple updates for the `stylelint-config-sass-guidelines` package, the main difference is the minimum required Node.js version.
`stylelint-config-sass-guidelines` versions:
- ^7.0.0  --> Node.js v10 or newer
- ^6.0.0 --> Node.js 8.7.0 or newer
- ^5.0.0 --> Node.js 6.x or newer

It is probably safer to update to version 5 because I don't know if we can assume that we always have/use a Node version greater than 6.

There aren't breaking changes for the `stylelint-config-sass-guidelines` version 5 update.
Here the most relevant:

[5.4.0]
- Fix patterns for variables like "$x1".
- Ignore all @-rules in max-nesting-depth.

[5.1.0]
- Ignore @each for max-nesting-depth.

[5.0.0]
- Added scss/at-rule-no-unknown rule.
- Added stylelint-scss and stylelint-order as dependencies.
- Node.js 6.x or greater is now required.